### PR TITLE
Accept string db-uri as parameter and don't crash if there are no q params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure.jdbc/clojure.jdbc-c3p0 "0.3.2-sam"
+(defproject org.clojars.seivadmas/clojure.jdbc-c3p0 "0.3.2-sam"
   :description "c3p0, a mature, highly concurrent JDBC connection pooling library for clojure.jdbc"
   :url "http://github.com/niwibe/clojure.jdbc-c3p0"
   :license {:name "Apache 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"
+(defproject clojure.jdbc/clojure.jdbc-c3p0 "0.3.2-sam"
   :description "c3p0, a mature, highly concurrent JDBC connection pooling library for clojure.jdbc"
   :url "http://github.com/niwibe/clojure.jdbc-c3p0"
   :license {:name "Apache 2.0"

--- a/src/jdbc/pool/c3p0.clj
+++ b/src/jdbc/pool/c3p0.clj
@@ -31,7 +31,7 @@
 
 (defn- uri->dbspec
   "Parses a dbspec as uri into a plain dbspec. This function accepts
-  a `java.net.URI` instane as parameter."
+  a `java.net.URI` instance as parameter."
   [^URI uri]
   (let [host (.getHost uri)
         port (.getPort uri)

--- a/src/jdbc/pool/c3p0.clj
+++ b/src/jdbc/pool/c3p0.clj
@@ -23,13 +23,15 @@
   plain map with parsed keys and values."
   [^URI uri]
   (let [^String query (.getQuery uri)]
-    (->> (for [^String kvs (.split query "&")] (into [] (.split kvs "=")))
-         (into {})
-         (walk/keywordize-keys))))
+    (if (nil? query)
+      {}
+      (->> (for [^String kvs (.split query "&")] (into [] (.split kvs "=")))
+           (into {})
+           (walk/keywordize-keys)))))
 
 (defn- uri->dbspec
-  "Parses a dbspec as uri into a plain dbspec. This function
-  accepts `java.net.URI` or `String` as parameter."
+  "Parses a dbspec as uri into a plain dbspec. This function accepts
+  a `java.net.URI` instane as parameter."
   [^URI uri]
   (let [host (.getHost uri)
         port (.getPort uri)
@@ -52,11 +54,12 @@
     (.close datasource)))
 
 (defn- normalize-dbspec
-  "Normalizes a dbspec for connection pool implementations."
+  "Normalizes a dbspec for connection pool implementations. Accepts a string,
+   URI instance or dbspec map as parameter"
   [{:keys [name vendor host port] :as dbspec}]
   (cond
-   (or (string? dbspec) (instance? URI dbspec))
-   (uri->dbspec dbspec)
+   (string? dbspec) (uri->dbspec (URI. dbspec))
+   (instance? URI dbspec) (uri->dbspec)
 
    (and name vendor)
    (let [host   (or host "127.0.0.1")


### PR DESCRIPTION
Fixes crash if db-spec is supplied as an ordinary string, corrects comments and fix crash if the URI does not have any query parameters.
