### PR TITLE
Incremental version bump of com.mchange/c3p0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.txt"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.mchange/c3p0 "0.9.5.2"]]
+                 [com.mchange/c3p0 "0.9.5.4"]]
 
   :profiles {:dev {:dependencies [[clojure.jdbc "0.4.0"]
                                   [com.h2database/h2 "1.4.196"]]}


### PR DESCRIPTION
Versions <=0.9.5.2 are vulnerable to CVE-2018-20433 (https://nvd.nist.gov/vuln/detail/CVE-2018-20433)
Versions <=0.9.5.3 are vulnerable to CVE-2019-5427 (https://nvd.nist.gov/vuln/detail/CVE-2019-5427)